### PR TITLE
build: simplified and hadolintd Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,79 @@
-FROM centos:7
+FROM centos:7 as base
 
-RUN mkdir /out
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /out
 
 # helmfile
-ENV HELMFILE_VERSION 0.98.2     
-RUN curl -LO https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64 && \
-  mv helmfile_linux_amd64 /out/helmfile && \
-  chmod +x /out/helmfile
+ARG HELMFILE_VERSION
+ENV HELMFILE_VERSION=${HELMFILE_VERSION:-0.98.2}
+RUN curl -Lo /out/helmfile https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64 && \
+    chmod 755 /out/helmfile
 
 # kubectl
-ENV KUBECTL_VERSION 1.16.0
-RUN curl -LO  https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
-  mv kubectl /out/kubectl && \
-  chmod +x /out/kubectl
+ARG KUBECTL_VERSION
+ENV KUBECTL_VERSION=${KUBECTL_VERSION:-1.16.0}
+RUN curl -Lo /out/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    chmod 755 /out/kubectl
 
 # helm 3
-ENV HELM3_VERSION 3.0.3
-RUN curl -f -L https://get.helm.sh/helm-v3.0.3-linux-386.tar.gz | tar xzv && \
-  mv linux-386/helm /out/
+ARG HELM3_VERSION
+ENV HELM3_VERSION=${HELM3_VERSION:-3.0.3}
+RUN curl -f -L https://get.helm.sh/helm-v${HELM3_VERSION}-linux-386.tar.gz | tar xzv --strip-components 1 -C /out
 
 # git
-ENV GIT_VERSION 2.21.1
-RUN yum install -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel && \
-    yum install -y gcc perl-ExtUtils-MakeMaker make
-RUN cd /usr/src  && \
-    curl -LO https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz  && \
-    tar xzf git-${GIT_VERSION}.tar.gz  && \
-    cd git-${GIT_VERSION} && \
-    make prefix=/usr/local/git all  && \
+ARG GIT_VERSION
+ENV GIT_VERSION=${GIT_VERSION:-2.21.1}
+RUN yum install -y \
+        curl-devel \
+        expat-devel \
+        gcc \
+        gettext-devel \
+        make \
+        openssl-devel \
+        perl-ExtUtils-MakeMaker \
+        zlib-devel
+
+WORKDIR /usr/src/git-${GIT_VERSION}
+RUN curl -L https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz | tar xvz --strip-components 1 && \
+    make prefix=/usr/local/git all && \
     make prefix=/usr/local/git install
 
-# Downloading gcloud package
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+# Downloading and installing the gcloud package
+WORKDIR /usr/local/gcloud
+RUN curl -L https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz |tar xvz -C /usr/local/gcloud && \
+    /usr/local/gcloud/google-cloud-sdk/install.sh && \
+    /usr/local/gcloud/google-cloud-sdk/bin/gcloud components install beta && \
+    /usr/local/gcloud/google-cloud-sdk/bin/gcloud components update
 
-# Installing the package
-RUN mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh && \
-  /usr/local/gcloud/google-cloud-sdk/bin/gcloud components install beta && \
-  /usr/local/gcloud/google-cloud-sdk/bin/gcloud components update
-
-FROM golang:1.12.17
-
-RUN mkdir /out
-RUN mkdir -p /go/src/github.com/jenkins-x-labs
+FROM golang:1.12.17 as jxl
 
 WORKDIR /go/src/github.com/jenkins-x-labs
 
+# hadolint ignore=DL3003
 RUN git clone https://github.com/jenkins-x/bdd-jx.git && \
   cd bdd-jx && \
-  make testbin && \
-  mv build/bddjx /out/bddjx
+  make testbin
 
+# hadolint ignore=DL3003
 RUN git clone https://github.com/jenkins-x/jx.git && \
   cd jx && \
   git checkout multicluster && \
-  make linux && \
-  mv build/linux/jx /out/jx
-
-# Adding the package path to local
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+  make linux
 
 # use a multi stage image so we don't include all the build tools above
 FROM centos:7
 # need to copy the whole git source else it doesn't clone the helm plugin repos below
-COPY --from=0 /usr/local/git /usr/local/git
-COPY --from=0 /usr/bin/make /usr/bin/make
-COPY --from=0 /out /usr/local/bin
-COPY --from=1 /out /usr/local/bin
-COPY --from=0 /usr/local/gcloud /usr/local/gcloud
+COPY --from=base /usr/local/git /usr/local/git
+COPY --from=base /usr/bin/make /usr/bin/make
+COPY --from=base /out /usr/local/bin
+COPY --from=base /usr/local/gcloud /usr/local/gcloud
+COPY --from=jxl /go/src/github.com/jenkins-x-labs/bdd-jx/build/bddjx /go/src/github.com/jenkins-x-labs/jx/build/linux/jx /usr/local/bin/
 
-ENV PATH /usr/local/bin:/usr/local/git/bin:$PATH:/usr/local/gcloud/google-cloud-sdk/bin
+ENV PATH=/usr/local/bin:/usr/local/git/bin:$PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-ENV HELM_PLUGINS /root/.cache/helm/plugins/
-ENV JX_HELM3 "true"
+ENV HELM_PLUGINS=/root/.cache/helm/plugins/
+ENV JX_HELM3="true"
 
 RUN helm plugin install https://github.com/databus23/helm-diff && \
     helm plugin install https://github.com/aslafy-z/helm-git.git


### PR DESCRIPTION
Refactors the `Dockerfile` build: removes `mkdir` commands (directories are created with `WORKDIR` instructions), pipes `curl` packages to `tar`, makes variables easier to override in builds [using `docker` `ARG`'s to set the `ENV`](https://docs.docker.com/engine/reference/builder/#using-arg-variables) (**note**: might break the `jx step create pr`), fixes the `helm3` download using the `ENV` variable, aliases the `docker` stages, consolidates and sorts and splits `yum` package installation on multiple lines following [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments). `Dockerfile` can be linted using [`hadolint`](https://github.com/hadolint/hadolint): `docker run --rm -i hadolint/hadolint < Dockerfile` - directories created by `make` are ignored inline.