### PR TITLE
Upgrade HELM3_VERSION to 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -LO  https://storage.googleapis.com/kubernetes-release/release/v${KUBEC
   chmod +x /out/kubectl
 
 # helm 3
-ENV HELM3_VERSION 3.1.2
+ENV HELM3_VERSION 3.2.0
 RUN curl -f -L https://get.helm.sh/helm-v${HELM3_VERSION}-linux-386.tar.gz | tar xzv && \
   mv linux-386/helm /usr/local/bin/helm && \
   mkdir -p $HOME/.jx/plugins/bin && \


### PR DESCRIPTION
hopping to fix: Error: UPGRADE FAILED: rendered manifests contain a new resource that already exists
https://github.com/helm/helm/issues/7418